### PR TITLE
Avoid downloading existing dependencies

### DIFF
--- a/autodl_files/depends_win.ps1
+++ b/autodl_files/depends_win.ps1
@@ -70,6 +70,16 @@ if(-not (Test-Path -PathType Container -Path "files")) {
 
 foreach($file in $files) {
     try {
+        if(Test-Path -PathType Leaf -Path "files\$file") {
+            Write-Verbose "File already exists: $file"
+            if(Test-Hash -File $file -Hash $hashes[$file]) {
+               Write-Host -BackgroundColor Black -ForegroundColor Cyan "Hash matches for $file"
+                continue
+            } else {
+               Write-Warning "Hash mismatch for existing $file"
+            }
+        }
+
         Retrieve-File -File $file -Url $urls[$file]
     } catch {
         Write-Host "Failed to download $file"


### PR DESCRIPTION
This commit stops `depends_win.ps1` from re-downloading files that already exist. If an existing file has the expected hash, the download is skipped. If the hash doesn't match, the file will be downloaded as usual, overwriting the non-matching one.